### PR TITLE
Add nullability annotations for RMQTLSOptions class

### DIFF
--- a/RMQClient/RMQTLSOptions.h
+++ b/RMQClient/RMQTLSOptions.h
@@ -3,17 +3,17 @@
 @interface RMQTLSOptions : MTLModel
 
 @property (nonatomic, readonly) BOOL useTLS;
-@property (nonatomic, readonly) NSString *peerName;
 @property (nonatomic, readonly) BOOL verifyPeer;
+@property (nonnull, nonatomic, readonly) NSString *peerName;
 
-+ (instancetype)fromURI:(NSString *)uri verifyPeer:(BOOL)verifyPeer;
-+ (instancetype)fromURI:(NSString *)uri;
-- (instancetype)initWithPeerName:(NSString *)peerName
-                      verifyPeer:(BOOL)verifyPeer
-                          pkcs12:(NSData *)pkcs12data
-                  pkcs12Password:(NSString *)password;
++ (nonnull instancetype)fromURI:(nonnull NSString *)uri verifyPeer:(BOOL)verifyPeer;
++ (nonnull instancetype)fromURI:(nonnull NSString *)uri;
+- (nonnull instancetype)initWithPeerName:(nonnull NSString *)peerName
+                              verifyPeer:(BOOL)verifyPeer
+                                  pkcs12:(nullable NSData *)pkcs12data
+                          pkcs12Password:(nullable NSString *)password;
 
-- (NSString *)authMechanism;
-- (NSArray *)certificatesWithError:(NSError **)error;
+- (nonnull NSString *)authMechanism;
+- (nullable NSArray *)certificatesWithError:(NSError *_Nullable *_Nullable)error;
 
 @end

--- a/RMQClient/RMQTLSOptions.m
+++ b/RMQClient/RMQTLSOptions.m
@@ -4,11 +4,13 @@
 #import "RMQURI.h"
 
 @interface RMQTLSOptions ()
+
 @property (nonatomic, readwrite) BOOL useTLS;
-@property (nonatomic, readwrite) NSString *peerName;
 @property (nonatomic, readwrite) BOOL verifyPeer;
-@property (nonatomic, readwrite) NSData *pkcs12data;
-@property (nonatomic, readwrite) NSString *pkcs12password;
+@property (nonnull, nonatomic, readwrite) NSString *peerName;
+@property (nullable, nonatomic, readwrite) NSData *pkcs12data;
+@property (nullable, nonatomic, readwrite) NSString *pkcs12password;
+
 @end
 
 @implementation RMQTLSOptions


### PR DESCRIPTION
In the following statement, 

`RMQTLSOptions *tlsOptions = [RMQTLSOptions fromURI:urlString verifyPeer:NO];`

the urlString was accidentally nil and the app crashed. When I checked the code, I found that the class has missing nullability annotations. So, I added these. 