### PR TITLE
Wrap @import statements into precompiler condition

### DIFF
--- a/RMQClient/RMQTCPSocketTransport.h
+++ b/RMQClient/RMQTCPSocketTransport.h
@@ -52,7 +52,9 @@
 #import <Foundation/Foundation.h>
 #import "RMQTransport.h"
 #import "RMQTLSOptions.h"
+#if defined(__has_feature) && __has_feature(modules)
 @import CocoaAsyncSocket;
+#endif
 
 @interface RMQTCPSocketTransport : NSObject<RMQTransport,GCDAsyncSocketDelegate>
 

--- a/RMQClient/RMQValues.h
+++ b/RMQClient/RMQValues.h
@@ -50,7 +50,9 @@
 // ---------------------------------------------------------------------------
 
 #import <Foundation/Foundation.h>
+#if defined(__has_feature) && __has_feature(modules)
 @import JKVValue;
+#endif
 #import "RMQParser.h"
 #import "RMQConnectionConfig.h"
 


### PR DESCRIPTION
Wrap @import statements into precompiler condition to avoid build problems when modules are disabled.