### PR TITLE
Introduce a new basicConsume version that accepts consumer arguments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,9 @@ before_script:
   - until lsof -i:5672; do echo "Waiting for RabbitMQ to start"; sleep 1; done
   - make test_user
 env:
-  - TARGET=tests_iOS TRAVIS_XCODE_SDK=iphonesimulator10.0
+  - TARGET=tests_iOS TRAVIS_XCODE_SDK=iphonesimulator10.0 iOS_VERSION=10.0
   - TARGET=tests_OSX TRAVIS_XCODE_SDK=macosx10.11
-script: travis_retry make $TARGET
+script: travis_retry make $TARGET iOS_VERSION=$iOS_VERSION
 after_failure:
   - cat /usr/local/var/log/rabbitmq/rabbit@localhost.log
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_script:
   - until lsof -i:5672; do echo "Waiting for RabbitMQ to start"; sleep 1; done
   - make test_user
 env:
-  - TARGET=tests_iOS TRAVIS_XCODE_SDK=iphonesimulator10.2
+  - TARGET=tests_iOS TRAVIS_XCODE_SDK=iphonesimulator10.0
   - TARGET=tests_OSX TRAVIS_XCODE_SDK=macosx10.11
 script: travis_retry make $TARGET
 after_failure:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_script:
   - until lsof -i:5672; do echo "Waiting for RabbitMQ to start"; sleep 1; done
   - make test_user
 env:
-  - TARGET=tests_iOS TRAVIS_XCODE_SDK=iphonesimulator10.0
+  - TARGET=tests_iOS TRAVIS_XCODE_SDK=iphonesimulator10.2
   - TARGET=tests_OSX TRAVIS_XCODE_SDK=macosx10.11
 script: travis_retry make $TARGET
 after_failure:

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ tests_iOS: test_dependencies
 		xcodebuild test \
 		-project RMQClient.xcodeproj \
 		-scheme RMQClient \
-		-destination 'platform=iOS Simulator,name=iPhone SE,OS=10.0' | \
+		-destination 'platform=iOS Simulator,name=iPhone SE,OS=10.2' | \
 		xcpretty
 
 tests_OSX: test_dependencies

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,13 @@
 tests: tests_iOS tests_OSX
 
+iOS_VERSION := 10.2
+
 tests_iOS: test_dependencies
 	set -o pipefail && \
 		xcodebuild test \
 		-project RMQClient.xcodeproj \
 		-scheme RMQClient \
-		-destination 'platform=iOS Simulator,name=iPhone SE,OS=10.2' | \
+		-destination 'platform=iOS Simulator,name=iPhone SE,OS=$(iOS_VERSION)' | \
 		xcpretty
 
 tests_OSX: test_dependencies

--- a/RMQClient/RMQAllocatedChannel.m
+++ b/RMQClient/RMQAllocatedChannel.m
@@ -226,14 +226,30 @@
     return consumer;
 }
 
+- (RMQConsumer *)basicConsume:(NSString *)queueName
+                      options:(RMQBasicConsumeOptions)options
+                    arguments:(RMQTable *)arguments
+                      handler:(RMQConsumerDeliveryHandler)handler {
+    RMQConsumer *consumer = [[RMQConsumer alloc] initWithChannel:self
+                                                       queueName:queueName
+                                                         options:options
+                                                       arguments:arguments];
+    [consumer onDelivery:handler];
+    [self basicConsume:consumer];
+    return consumer;
+}
+
 - (void)basicConsume:(RMQConsumer *)consumer {
     [self.dispatcher sendSyncMethod:[[RMQBasicConsume alloc] initWithQueue:consumer.queueName
                                                                consumerTag:consumer.tag
-                                                                   options:consumer.options]
+                                                                   options:consumer.options
+                                                                   arguments:consumer.arguments]
                   completionHandler:^(RMQFrameset *frameset) {
                       self.consumers[consumer.tag] = consumer;
                   }];
 }
+
+
 
 - (NSString *)generateConsumerTag {
     return [self.nameGenerator generateWithPrefix:@"rmq-objc-client.gen-"];

--- a/RMQClient/RMQChannel.h
+++ b/RMQClient/RMQChannel.h
@@ -161,7 +161,7 @@
  */
 - (nonnull RMQConsumer *)basicConsume:(nonnull NSString *)queueName
                               options:(RMQBasicConsumeOptions)options
-                            arguments:(RMQTable *)arguments
+                            arguments:(RMQTable * _Nonnull)arguments
                               handler:(RMQConsumerDeliveryHandler _Nonnull)handler;
                               
 /// @brief Internal method used by a consumer object

--- a/RMQClient/RMQChannel.h
+++ b/RMQClient/RMQChannel.h
@@ -155,6 +155,15 @@
  */
 - (void)basicConsume:(nonnull RMQConsumer *)consumer;
 
+/*!
+ * @brief Consume messages from a queue
+ * @see RMQQueue's subscribe method (which has variants with defaults)
+ */
+- (nonnull RMQConsumer *)basicConsume:(nonnull NSString *)queueName
+                              options:(RMQBasicConsumeOptions)options
+                            arguments:(RMQTable *)arguments
+                              handler:(RMQConsumerDeliveryHandler _Nonnull)handler;
+                              
 /// @brief Internal method used by a consumer object
 - (nonnull NSString *)generateConsumerTag;
 

--- a/RMQClient/RMQConsumer.h
+++ b/RMQClient/RMQConsumer.h
@@ -60,10 +60,15 @@
 @property (nonatomic, readonly) NSString *queueName;
 @property (nonatomic, readonly) RMQBasicConsumeOptions options;
 @property (nonatomic, readonly) NSString *tag;
+@property (nonatomic, readonly) RMQTable *arguments;
 
 - (instancetype)initWithChannel:(id<RMQChannel>)channel
                       queueName:(NSString *)queueName
                         options:(RMQBasicConsumeOptions)options;
+- (instancetype)initWithChannel:(id<RMQChannel>)channel
+                      queueName:(NSString *)queueName
+                        options:(RMQBasicConsumeOptions)options
+                      arguments:(RMQTable *)arguments;
 - (void)onDelivery:(RMQConsumerDeliveryHandler)handler;
 - (void)onCancellation:(RMQConsumerCancellationHandler)handler;
 - (void)consume:(RMQMessage *)message;

--- a/RMQClient/RMQConsumer.m
+++ b/RMQClient/RMQConsumer.m
@@ -59,6 +59,7 @@
 @property (nonatomic, readwrite) id<RMQChannel> channel;
 @property (nonatomic, readwrite) RMQConsumerDeliveryHandler deliveryHandler;
 @property (nonatomic, readwrite) RMQConsumerCancellationHandler cancellationHandler;
+@property (nonatomic, readwrite) RMQTable *arguments;
 @end
 
 @implementation RMQConsumer
@@ -70,6 +71,24 @@
     if (self) {
         self.queueName = queueName;
         self.options = options;
+        self.arguments = [RMQTable new];
+        self.tag = [channel generateConsumerTag];
+        self.channel = channel;
+        self.cancellationHandler = ^(){};
+        self.deliveryHandler = ^(id _){};
+    }
+    return self;
+}
+
+- (instancetype)initWithChannel:(id<RMQChannel>)channel
+                      queueName:(NSString *)queueName
+                        options:(RMQBasicConsumeOptions)options
+                      arguments:(RMQTable *)arguments {
+    self = [super init];
+    if (self) {
+        self.queueName = queueName;
+        self.options = options;
+        self.arguments = arguments;
         self.tag = [channel generateConsumerTag];
         self.channel = channel;
         self.cancellationHandler = ^(){};

--- a/RMQClient/RMQMethods+Convenience.h
+++ b/RMQClient/RMQMethods+Convenience.h
@@ -57,6 +57,11 @@
                   consumerTag:(NSString *)consumerTag
                       options:(RMQBasicConsumeOptions)options;
 
+- (instancetype)initWithQueue:(NSString *)queueName
+                  consumerTag:(NSString *)consumerTag
+                      options:(RMQBasicConsumeOptions)options
+                      arguments:(RMQTable *)arguments;
+
 @end
 
 @interface RMQBasicQos (Convenience)

--- a/RMQClient/RMQMethods+Convenience.m
+++ b/RMQClient/RMQMethods+Convenience.m
@@ -63,6 +63,17 @@
                          arguments:[RMQTable new]];
 }
 
+- (instancetype)initWithQueue:(NSString *)queueName
+                  consumerTag:(NSString *)consumerTag
+                      options:(RMQBasicConsumeOptions)options
+                      arguments:(RMQTable *)arguments {
+    return [self initWithReserved1:[[RMQShort alloc] init:0]
+                             queue:[[RMQShortstr alloc] init:queueName]
+                       consumerTag:[[RMQShortstr alloc] init:consumerTag]
+                           options:options
+                         arguments:arguments];
+}
+
 @end
 
 @implementation RMQBasicQos (Convenience)

--- a/RMQClient/RMQQueue.h
+++ b/RMQClient/RMQQueue.h
@@ -127,5 +127,11 @@
  */
 - (RMQConsumer *)subscribe:(RMQBasicConsumeOptions)options
                    handler:(RMQConsumerDeliveryHandler)handler;
-
+/*!
+ * @brief Perform an RMQChannel#basicConsume with the current queue's name, options and arguments.
+ *        Pass an RMQConsumer instance to that method to customise cancellation behaviour.
+ */
+- (RMQConsumer *)subscribe:(RMQBasicConsumeOptions)options
+                 arguments:(RMQTable *)arguments
+                   handler:(RMQConsumerDeliveryHandler)handler;
 @end

--- a/RMQClient/RMQQueue.m
+++ b/RMQClient/RMQQueue.m
@@ -155,4 +155,12 @@
                    handler:handler];
 }
 
+- (RMQConsumer *)subscribe:(RMQBasicConsumeOptions)options
+                 arguments:(RMQTable *)arguments
+                   handler:(RMQConsumerDeliveryHandler)handler {
+    return [self.channel basicConsume:self.name
+                              options:options
+                            arguments:arguments
+                              handler:handler];
+}
 @end

--- a/RMQClient/RMQUnallocatedChannel.m
+++ b/RMQClient/RMQUnallocatedChannel.m
@@ -110,6 +110,18 @@
     [self err];
 }
 
+/*!
+ * @brief Consume messages from a queue
+ * @see RMQQueue's subscribe method (which has variants with defaults)
+ */
+- (nonnull RMQConsumer *)basicConsume:(nonnull NSString *)queueName
+                              options:(RMQBasicConsumeOptions)options
+                            arguments:(RMQTable * _Nonnull)arguments
+                              handler:(RMQConsumerDeliveryHandler _Nonnull)handler {
+    [self err];
+    return nil;
+}
+
 - (NSString *)generateConsumerTag {
     [self err];
     return nil;

--- a/RMQClientTests/ChannelSpy.swift
+++ b/RMQClientTests/ChannelSpy.swift
@@ -217,6 +217,18 @@
         return consumer!
     }
 
+    func basicConsume(_ queueName: String, options: RMQBasicConsumeOptions = [], arguments: RMQTable, handler: @escaping RMQConsumerDeliveryHandler) -> RMQConsumer {
+        lastReceivedBasicConsumeOptions = options
+        lastReceivedBasicConsumeBlock = handler
+        if let msg = stubbedBasicConsumeError {
+            let e = NSError(domain: RMQErrorDomain, code: 0, userInfo: [NSLocalizedDescriptionKey: msg])
+            delegateSentToActivate?.channel(self, error: e)
+        }
+        let consumer = RMQConsumer(channel: self, queueName: queueName, options: options, arguments: arguments)
+        consumer?.onDelivery(handler)
+        return consumer!
+    }
+
     func basicConsume(_ consumer: RMQConsumer) {
     }
 


### PR DESCRIPTION
This is #107 by @timhonders with a few updates that make tests run (and pass).

Fixes #106.