### PR TITLE
Remove nested frameworks from RMQClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ Test-driven from Swift and implemented in Objective-C, to avoid burdening Object
    ```
    carthage bootstrap
    ```
-   
-1. In your Xcode project, in the **Build Phases** section of your target, open up **Link Binary With Libraries**.
-   Now drag the following frameworks to the list (`Mac` for OS X):
+
+1. In your Xcode project, in the **Build Phases** section of your target, open up **Link
+   Binary With Libraries**. Now drag the following frameworks to the list (`Mac` for OS X):
    * `Carthage/Build/iOS/RMQClient.framework`
    * `Carthage/Build/iOS/CocoaAsyncSocket.framework`
    * `Carthage/Build/iOS/JKVValue.framework`

--- a/README.md
+++ b/README.md
@@ -41,13 +41,16 @@ Test-driven from Swift and implemented in Objective-C, to avoid burdening Object
    ```
    carthage bootstrap
    ```
-1. In your Xcode project, in the **Build Phases** section of your target, open up **Link
-   Binary With Libraries**. Now drag e.g. `Carthage/Build/iOS/RMQClient.framework`
-   (choose Mac for OSX) into this list.
+   
+1. In your Xcode project, in the **Build Phases** section of your target, open up **Link Binary With Libraries**.
+   Now drag the following frameworks to the list (`Mac` for OS X):
+   * `Carthage/Build/iOS/RMQClient.framework`
+   * `Carthage/Build/iOS/CocoaAsyncSocket.framework`
+   * `Carthage/Build/iOS/JKVValue.framework`
 1. If you don't already have one, click the '+' icon under **Build Phases** to add a
 **Copy Files** phase.
 1. Under **Destination**, choose **Frameworks**.
-1. Click the '+' and add RMQClient.framework. Ensure **Code Sign On Copy** is checked.
+1. Click the '+' and add the same frameworks. Ensure **Code Sign On Copy** is checked.
 
 ## Installation with [CocoaPods](https://cocoapods.org/)
 

--- a/RMQClient.xcodeproj/project.pbxproj
+++ b/RMQClient.xcodeproj/project.pbxproj
@@ -201,6 +201,10 @@
 		AEF1E8FC1CBEA057000C7AB8 /* RMQHandshaker.m in Sources */ = {isa = PBXBuildFile; fileRef = AEF1E8FA1CBEA057000C7AB8 /* RMQHandshaker.m */; };
 		AEFFE6381C8EE7B30039D652 /* RMQConnectionConfig.h in Headers */ = {isa = PBXBuildFile; fileRef = AEFFE6361C8EE7B30039D652 /* RMQConnectionConfig.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AEFFE6391C8EE7B30039D652 /* RMQConnectionConfig.m in Sources */ = {isa = PBXBuildFile; fileRef = AEFFE6371C8EE7B30039D652 /* RMQConnectionConfig.m */; };
+		FBCA03A11ED774DA00610AEC /* CocoaAsyncSocket.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FBCA039F1ED774DA00610AEC /* CocoaAsyncSocket.framework */; };
+		FBCA03A21ED774DA00610AEC /* JKVValue.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FBCA03A01ED774DA00610AEC /* JKVValue.framework */; };
+		FBCA03A51ED774E600610AEC /* CocoaAsyncSocket.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FBCA03A31ED774E600610AEC /* CocoaAsyncSocket.framework */; };
+		FBCA03A61ED774E600610AEC /* JKVValue.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FBCA03A41ED774E600610AEC /* JKVValue.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -408,6 +412,10 @@
 		AEF1E8FA1CBEA057000C7AB8 /* RMQHandshaker.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RMQHandshaker.m; sourceTree = "<group>"; };
 		AEFFE6361C8EE7B30039D652 /* RMQConnectionConfig.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RMQConnectionConfig.h; sourceTree = "<group>"; };
 		AEFFE6371C8EE7B30039D652 /* RMQConnectionConfig.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RMQConnectionConfig.m; sourceTree = "<group>"; };
+		FBCA039F1ED774DA00610AEC /* CocoaAsyncSocket.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CocoaAsyncSocket.framework; path = Carthage/Build/iOS/CocoaAsyncSocket.framework; sourceTree = "<group>"; };
+		FBCA03A01ED774DA00610AEC /* JKVValue.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JKVValue.framework; path = Carthage/Build/iOS/JKVValue.framework; sourceTree = "<group>"; };
+		FBCA03A31ED774E600610AEC /* CocoaAsyncSocket.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CocoaAsyncSocket.framework; path = Carthage/Build/Mac/CocoaAsyncSocket.framework; sourceTree = "<group>"; };
+		FBCA03A41ED774E600610AEC /* JKVValue.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JKVValue.framework; path = Carthage/Build/Mac/JKVValue.framework; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -423,6 +431,10 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				FBCA03A51ED774E600610AEC /* CocoaAsyncSocket.framework in Frameworks */,
+				FBCA03A21ED774DA00610AEC /* JKVValue.framework in Frameworks */,
+				FBCA03A61ED774E600610AEC /* JKVValue.framework in Frameworks */,
+				FBCA03A11ED774DA00610AEC /* CocoaAsyncSocket.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -732,6 +744,7 @@
 				AEE7FE9F1C3BCA6000DF8C4F /* RMQClientTests */,
 				AEA45ED81C440FE400FE1F62 /* RMQClientIntegrationTests */,
 				AEE7FE921C3BCA6000DF8C4F /* Products */,
+				FBCA039E1ED774C300610AEC /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -837,6 +850,17 @@
 				AE41C5621C51A2D500129207 /* RMQTransportContract.swift */,
 			);
 			name = Connection;
+			sourceTree = "<group>";
+		};
+		FBCA039E1ED774C300610AEC /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				FBCA03A31ED774E600610AEC /* CocoaAsyncSocket.framework */,
+				FBCA03A41ED774E600610AEC /* JKVValue.framework */,
+				FBCA039F1ED774DA00610AEC /* CocoaAsyncSocket.framework */,
+				FBCA03A01ED774DA00610AEC /* JKVValue.framework */,
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -1340,6 +1364,11 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 8;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+					"$(PROJECT_DIR)/Carthage/Build/Mac",
+				);
 				INFOPLIST_FILE = RMQClient/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
@@ -1358,6 +1387,11 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 8;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+					"$(PROJECT_DIR)/Carthage/Build/Mac",
+				);
 				INFOPLIST_FILE = RMQClient/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;

--- a/RMQClient.xcodeproj/project.pbxproj
+++ b/RMQClient.xcodeproj/project.pbxproj
@@ -937,7 +937,6 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = AEE7FEA51C3BCA6000DF8C4F /* Build configuration list for PBXNativeTarget "RMQClient" */;
 			buildPhases = (
-				AE637E2C1C4CFF28006F9EDF /* ShellScript */,
 				AEE7FE8C1C3BCA6000DF8C4F /* Sources */,
 				AEE7FE8D1C3BCA6000DF8C4F /* Frameworks */,
 				AEE7FE8E1C3BCA6000DF8C4F /* Headers */,
@@ -1035,24 +1034,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
-
-/* Begin PBXShellScriptBuildPhase section */
-		AE637E2C1C4CFF28006F9EDF /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 12;
-			files = (
-			);
-			inputPaths = (
-				CocoaAsyncSocket,
-				JKVValue,
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "case \"$PLATFORM_NAME\" in\nmacosx) plat=Mac;;\niphone*) plat=iOS;;\n*) echo \\\"error: Unknown PLATFORM_NAME: $PLATFORM_NAME\\\"; exit 1;;\nesac\nfor (( n = 0; n < SCRIPT_INPUT_FILE_COUNT; n++ )); do\nVAR=SCRIPT_INPUT_FILE_$n\nframework=$(basename \"${!VAR}\")\nexport SCRIPT_INPUT_FILE_$n=\"$SRCROOT\"/Carthage/Build/$plat/\"$framework\".framework\ndone\n\n/usr/local/bin/carthage copy-frameworks || exit\n\necho \"Copying frameworks\"\nfor (( n = 0; n < SCRIPT_INPUT_FILE_COUNT; n++ )); do\nVAR=SCRIPT_INPUT_FILE_$n\nsource=${!VAR}\ndest=${BUILT_PRODUCTS_DIR}/$(basename \"$source\")\necho \"$source => $dest\"\nditto \"$source\" \"$dest\" || exit\ndone\n\necho \"Copying debug symbols\"\nfor (( n = 0; n < SCRIPT_INPUT_FILE_COUNT; n++ )); do\nVAR=SCRIPT_INPUT_FILE_$n\nsource=${!VAR}.dSYM\ndest=${BUILT_PRODUCTS_DIR}/$(basename \"$source\")\necho \"$source => $dest\"\nditto \"$source\" \"$dest\" || exit\ndone";
-		};
-/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		AEA45ED31C440FE400FE1F62 /* Sources */ = {


### PR DESCRIPTION
This is preventing us from going to app store.

Note that this relies on a temporary fork of RMQClient with changes.

https://app.asana.com/0/339308335043144/350504162409951