### PR TITLE
 Make it possible for apps to provide a custom connection name

### DIFF
--- a/RMQClient/RMQConnection.h
+++ b/RMQClient/RMQConnection.h
@@ -80,9 +80,9 @@
                             waiterFactory:(nonnull id<RMQWaiterFactory>)waiterFactory
                           heartbeatSender:(nonnull id<RMQHeartbeatSender>)heartbeatSender;
 
-/// @brief Connection tuning, customisable TLS, all recovery options.
+/// @brief Connection tuning, customisable config, all recovery options.
 - (nonnull instancetype)initWithUri:(nonnull NSString *)uri
-                         tlsOptions:(nonnull RMQTLSOptions *)tlsOptions
+         userProvidedConnectionName:(nonnull NSString *)connectionName
                          channelMax:(nonnull NSNumber *)channelMax
                            frameMax:(nonnull NSNumber *)frameMax
                           heartbeat:(nonnull NSNumber *)heartbeat
@@ -95,6 +95,42 @@
                        recoverAfter:(nonnull NSNumber *)recoveryInterval
                    recoveryAttempts:(nonnull NSNumber *)recoveryAttempts
          recoverFromConnectionClose:(BOOL)shouldRecoverFromConnectionClose;
+
+/// @brief Connection tuning, customisable TLS, key recovery options.
+- (nonnull instancetype)initWithUri:(nonnull NSString *)uri
+                         tlsOptions:(nonnull RMQTLSOptions *)tlsOptions
+                           delegate:(nullable id<RMQConnectionDelegate>)delegate
+                       recoverAfter:(nonnull NSNumber *)recoveryInterval
+                   recoveryAttempts:(nonnull NSNumber *)recoveryAttempts
+         recoverFromConnectionClose:(BOOL)shouldRecoverFromConnectionClose;
+
+/// @brief Connection tuning, customisable TLS and connection name, key recovery options.
+- (nonnull instancetype)initWithUri:(nonnull NSString *)uri
+                         tlsOptions:(nonnull RMQTLSOptions *)tlsOptions
+         userProvidedConnectionName:(nullable NSString *)connectionName
+                           delegate:(nullable id<RMQConnectionDelegate>)delegate
+                       recoverAfter:(nonnull NSNumber *)recoveryInterval
+                   recoveryAttempts:(nonnull NSNumber *)recoveryAttempts
+         recoverFromConnectionClose:(BOOL)shouldRecoverFromConnectionClose;
+
+/// @brief Connection tuning, customisable TLS, all recovery options.
+- (nonnull instancetype)initWithUri:(nonnull NSString *)uri
+         userProvidedConnectionName:(nullable NSString *)connectionName
+                           delegate:(nullable id<RMQConnectionDelegate>)delegate
+                       recoverAfter:(nonnull NSNumber *)recoveryInterval
+                   recoveryAttempts:(nonnull NSNumber *)recoveryAttempts
+         recoverFromConnectionClose:(BOOL)shouldRecoverFromConnectionClose;
+
+/// @brief Connection configuration.
+- (nonnull instancetype)initWithUri:(nonnull NSString *)uri
+         userProvidedConnectionName:(nonnull NSString *)connectionName
+                           delegate:(nullable id<RMQConnectionDelegate>)delegate;
+
+/// @brief TLS, connection configuration and delegate.
+- (nonnull instancetype)initWithUri:(nonnull NSString *)uri
+                         tlsOptions:(nonnull RMQTLSOptions *)tlsOptions
+         userProvidedConnectionName:(nonnull NSString *)connectionName
+                           delegate:(nullable id<RMQConnectionDelegate>)delegate;
 
 /// @brief Allows setting of timeouts
 - (nonnull instancetype)initWithUri:(nonnull NSString *)uri

--- a/RMQClient/RMQConnectionConfig.h
+++ b/RMQClient/RMQConnectionConfig.h
@@ -63,6 +63,7 @@ extern NSInteger const RMQChannelMaxDefault;
 @property (nonnull, nonatomic, readonly) NSString *vhost;
 @property (nonnull, nonatomic, readonly) RMQCredentials *credentials;
 @property (nonnull, nonatomic, readonly) NSString *authMechanism;
+@property (nonatomic, readonly) NSString *userProvidedConnectionName;
 @property (nonnull, nonatomic, readonly) id<RMQConnectionRecovery> recovery;
 
 - (nonnull instancetype)initWithCredentials:(nonnull RMQCredentials *)credentials
@@ -77,5 +78,21 @@ extern NSInteger const RMQChannelMaxDefault;
                                   heartbeat:(nonnull NSNumber *)heartbeat
                                       vhost:(nonnull NSString *)vhost
                               authMechanism:(nonnull NSString *)authMechanism
+                                   recovery:(nonnull id<RMQConnectionRecovery>)recovery;
+
+- (nonnull instancetype)initWithCredentials:(nonnull RMQCredentials *)credentials
+                                 channelMax:(nonnull NSNumber *)channelMax
+                                   frameMax:(nonnull NSNumber *)frameMax
+                                  heartbeat:(nonnull NSNumber *)heartbeat
+                                      vhost:(nonnull NSString *)vhost
+                              authMechanism:(nonnull NSString *)authMechanism
+                 userProvidedConnectionName:(nonnull NSString *)userProvidedConnectionName
+                                   recovery:(nonnull id<RMQConnectionRecovery>)recovery;
+
+- (nonnull instancetype)initWithCredentials:(nonnull RMQCredentials *)credentials
+                                  heartbeat:(nonnull NSNumber *)heartbeat
+                                      vhost:(nonnull NSString *)vhost
+                              authMechanism:(nonnull NSString *)authMechanism
+                 userProvidedConnectionName:(nonnull NSString *)userProvidedConnectionName
                                    recovery:(nonnull id<RMQConnectionRecovery>)recovery;
 @end

--- a/RMQClient/RMQConnectionConfig.m
+++ b/RMQClient/RMQConnectionConfig.m
@@ -66,6 +66,7 @@ NSInteger const RMQChannelMaxDefault = 127;
 @property (nonnull, nonatomic, readwrite) NSString *vhost;
 @property (nonnull, nonatomic, readwrite) RMQCredentials *credentials;
 @property (nonnull, nonatomic, readwrite) NSString *authMechanism;
+@property (nonatomic, readwrite) NSString *userProvidedConnectionName;
 @property (nonnull, nonatomic, readwrite) id<RMQConnectionRecovery> recovery;
 @end
 
@@ -101,6 +102,44 @@ NSInteger const RMQChannelMaxDefault = 127;
                            heartbeat:heartbeat
                                vhost:vhost
                        authMechanism:authMechanism
+                            recovery:recovery];
+}
+
+- (instancetype)initWithCredentials:(RMQCredentials *)credentials
+                         channelMax:(NSNumber *)channelMax
+                           frameMax:(NSNumber *)frameMax
+                          heartbeat:(NSNumber *)heartbeat
+                              vhost:(nonnull NSString *)vhost
+                      authMechanism:(nonnull NSString *)authMechanism
+         userProvidedConnectionName:(nonnull NSString *)userProvidedConnectionName
+                           recovery:(nonnull id<RMQConnectionRecovery>)recovery {
+    self = [super init];
+    if (self) {
+        self.credentials = credentials;
+        self.channelMax = channelMax;
+        self.frameMax = frameMax;
+        self.heartbeat = heartbeat;
+        self.vhost = vhost;
+        self.authMechanism = authMechanism;
+        self.userProvidedConnectionName = userProvidedConnectionName;
+        self.recovery = recovery;
+    }
+    return self;
+}
+
+- (instancetype)initWithCredentials:(RMQCredentials *)credentials
+                          heartbeat:(NSNumber *)heartbeat
+                              vhost:(nonnull NSString *)vhost
+                      authMechanism:(nonnull NSString *)authMechanism
+         userProvidedConnectionName:(nonnull NSString *)userProvidedConnectionName
+                           recovery:(nonnull id<RMQConnectionRecovery>)recovery {
+    return [self initWithCredentials:credentials
+                          channelMax:[NSNumber numberWithInteger:RMQChannelMaxDefault]
+                            frameMax:[NSNumber numberWithInteger:RMQFrameMax]
+                           heartbeat:heartbeat
+                               vhost:vhost
+                       authMechanism:authMechanism
+          userProvidedConnectionName:userProvidedConnectionName
                             recovery:recovery];
 }
 @end

--- a/RMQClient/RMQHandshaker.m
+++ b/RMQClient/RMQHandshaker.m
@@ -110,12 +110,19 @@
     NSBundle *bundle = [NSBundle bundleWithIdentifier:@"io.pivotal.RMQClient"];
     NSString *version = bundle.infoDictionary[@"CFBundleShortVersionString"];
 
-    RMQTable *clientProperties = [[RMQTable alloc] init:
-                                  @{@"capabilities" : capabilities,
-                                    @"product"      : [[RMQLongstr alloc] init:@"RMQClient"],
-                                    @"platform"     : [[RMQLongstr alloc] init:@"iOS"],
-                                    @"version"      : [[RMQLongstr alloc] init:version],
-                                    @"information"  : [[RMQLongstr alloc] init:@"https://github.com/rabbitmq/rabbitmq-objc-client"]}];
+    NSDictionary *libraryProperties = @{@"capabilities" : capabilities,
+                                        @"product"      : [[RMQLongstr alloc] init:@"RMQClient"],
+                                        @"platform"     : [[RMQLongstr alloc] init:@"iOS"],
+                                        @"version"      : [[RMQLongstr alloc] init:version],
+                                        @"information"  : [[RMQLongstr alloc] init:@"https://github.com/rabbitmq/rabbitmq-objc-client"]};
+    NSMutableDictionary *combinedProperties = [[NSMutableDictionary alloc] initWithDictionary:libraryProperties];
+
+    NSString *userProvidedConnectionName = [self.config userProvidedConnectionName];
+    if (userProvidedConnectionName != nil) {
+        [combinedProperties setObject:[[RMQLongstr alloc] init:userProvidedConnectionName]
+                               forKey:@"connection_name"];
+    }
+    RMQTable *clientProperties = [[RMQTable alloc] init:combinedProperties];
 
     return [[RMQConnectionStartOk alloc] initWithClientProperties:clientProperties
                                                         mechanism:[[RMQShortstr alloc] init:self.config.authMechanism]

--- a/RMQClientIntegrationTests/ChannelLifecycleIntegrationTest.swift
+++ b/RMQClientIntegrationTests/ChannelLifecycleIntegrationTest.swift
@@ -123,7 +123,7 @@ class ChannelLifecycleIntegrationTest: XCTestCase {
         let ch2 = conn.createChannel()
 
         let qName = "objc.tests.\(Int.random(in: 200...1000))"
-        ch1.queue(qName, options: [.exclusive])
+        ch1.queue(qName, options: [.autoDelete])
 
         // uses a different set of properties from
         // the original declaration

--- a/RMQClientIntegrationTests/ConnectionLifecycleIntegrationTest.swift
+++ b/RMQClientIntegrationTests/ConnectionLifecycleIntegrationTest.swift
@@ -120,5 +120,18 @@ class ConnectionLifecycleIntegrationTest: XCTestCase {
         XCTAssertNotNil(props["product"] ?? nil)
         XCTAssertNotNil(props["version"] ?? nil)
         XCTAssertNotNil(props["capabilities"] ?? nil)
+
+        conn.blockingClose()
+    }
+
+    func testUserProvidedConnectionName() {
+        let conn = RMQConnection(uri: IntegrationHelper.defaultEndpoint,
+                                 userProvidedConnectionName: "testUserProvidedConnectionName.1",
+                                 delegate: RMQConnectionDelegateLogger())
+        conn.start()
+        XCTAssertTrue(IntegrationHelper.pollUntilConnected(conn))
+
+        XCTAssert(conn.isOpen())
+        conn.blockingClose()
     }
 }

--- a/RMQClientIntegrationTests/ConnectionRecoveryIntegrationTest.swift
+++ b/RMQClientIntegrationTests/ConnectionRecoveryIntegrationTest.swift
@@ -157,15 +157,8 @@ class ConnectionRecoveryIntegrationTest: XCTestCase {
 
         let conn = RMQConnection(uri: plainEndpoint,
                                  tlsOptions: RMQTLSOptions.fromURI(plainEndpoint),
-                                 channelMax: RMQChannelMaxDefault as NSNumber,
-                                 frameMax: RMQFrameMax as NSNumber,
-                                 heartbeat: 10,
-                                 connectTimeout: 15,
-                                 readTimeout: 30,
-                                 writeTimeout: 30,
-                                 syncTimeout: 10,
+                                 userProvidedConnectionName: nil,
                                  delegate: delegate,
-                                 delegateQueue: DispatchQueue.main,
                                  recoverAfter: recoveryInterval as NSNumber,
                                  recoveryAttempts: 5,
                                  recoverFromConnectionClose: true)


### PR DESCRIPTION
Closes #155, references #154.

@grsteffens it took a couple of attempts, I like this API better than what I had in mind at first (a simpler way to instantiate `RMQConnectionConfig` which is not really meant to be used by 99% of users).