### PR TITLE
URL Cleanup

### DIFF
--- a/codegen/amqp0-9-1.extended.xml
+++ b/codegen/amqp0-9-1.extended.xml
@@ -132,7 +132,7 @@
 
     Links to full AMQP specification:
     =================================
-    http://www.amqp.org
+    https://www.amqp.org
 -->
 
 <!--


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://www.amqp.org with 1 occurrences migrated to:  
  https://www.amqp.org ([https](https://www.amqp.org) result 200).