### PR TITLE
URL Cleanup

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -40,5 +40,5 @@ appropriate to the circumstances. Maintainers are obligated to maintain confiden
 with regard to the reporter of an incident.
 
 This Code of Conduct is adapted from the
-[Contributor Covenant](http://contributor-covenant.org), version 1.3.0, available at
-[contributor-covenant.org/version/1/3/0/](http://contributor-covenant.org/version/1/3/0/)
+[Contributor Covenant](https://contributor-covenant.org), version 1.3.0, available at
+[contributor-covenant.org/version/1/3/0/](https://contributor-covenant.org/version/1/3/0/)

--- a/LICENSE-MPL-RabbitMQ
+++ b/LICENSE-MPL-RabbitMQ
@@ -437,7 +437,7 @@ EXHIBIT A -Mozilla Public License.
      ``The contents of this file are subject to the Mozilla Public License
      Version 1.1 (the "License"); you may not use this file except in
      compliance with the License. You may obtain a copy of the License at
-     http://www.mozilla.org/MPL/
+     https://www.mozilla.org/MPL/
 
      Software distributed under the License is distributed on an "AS IS"
      basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ codebases before the ecosystem converts to 95+% Swift.
 
 ## Documentation
 
- * [Several RabbitMQ tutorials](http://www.rabbitmq.com/getstarted.html) are provided for
+ * [Several RabbitMQ tutorials](https://www.rabbitmq.com/getstarted.html) are provided for
    this client library.
 
 ### (Basic) Usage Example
@@ -105,7 +105,7 @@ codebases before the ecosystem converts to 95+% Swift.
    conn.close()
    ```
 
-See [the tutorials](http://www.rabbitmq.com/getstarted.html) for more detailed instructions.
+See [the tutorials](https://www.rabbitmq.com/getstarted.html) for more detailed instructions.
 
 
 ## Running Tests

--- a/RMQClient.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/RMQClient.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>IDEDidComputeMac32BitWarning</key>

--- a/RMQClient.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/RMQClient.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>IDEWorkspaceSharedSettings_AutocreateContextsIfNeeded</key>

--- a/RMQClient.xcodeproj/xcuserdata/pivotal.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/RMQClient.xcodeproj/xcuserdata/pivotal.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>SchemeUserState</key>

--- a/RMQClient/Info.plist
+++ b/RMQClient/Info.plist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>CFBundleDevelopmentRegion</key>

--- a/RMQClient/RMQAllocatedChannel.m
+++ b/RMQClient/RMQAllocatedChannel.m
@@ -417,7 +417,7 @@ completionHandler:(RMQConsumerDeliveryHandler)userCompletionHandler {
 
 - (void)basicRecover
 {
-    // According to http://www.rabbitmq.com/specification.html "Recovery with requeue=false is not supported."
+    // According to https://www.rabbitmq.com/specification.html "Recovery with requeue=false is not supported."
     [self.dispatcher sendSyncMethod:[[RMQBasicRecover alloc] initWithOptions:RMQBasicRecoverRequeue]];
 }
 

--- a/RMQClient/RMQConnectionDelegate.h
+++ b/RMQClient/RMQConnectionDelegate.h
@@ -61,12 +61,12 @@ failedToConnectWithError:(NSError *)error;
 /// @brief Called when a connection disconnects for any reason
 - (void)   connection:(RMQConnection *)connection
 disconnectedWithError:(NSError *)error;
-/// @brief Called before the configured <a href="http://www.rabbitmq.com/api-guide.html#recovery">automatic connection recovery</a> sleep.
+/// @brief Called before the configured <a href="https://www.rabbitmq.com/api-guide.html#recovery">automatic connection recovery</a> sleep.
 - (void)willStartRecoveryWithConnection:(RMQConnection *)connection;
-/// @brief Called after the configured <a href="http://www.rabbitmq.com/api-guide.html#recovery">automatic connection recovery</a> sleep.
+/// @brief Called after the configured <a href="https://www.rabbitmq.com/api-guide.html#recovery">automatic connection recovery</a> sleep.
 - (void)startingRecoveryWithConnection:(RMQConnection *)connection;
 /*!
- * @brief Called when <a href="http://www.rabbitmq.com/api-guide.html#recovery">automatic connection recovery</a> has succeeded.
+ * @brief Called when <a href="https://www.rabbitmq.com/api-guide.html#recovery">automatic connection recovery</a> has succeeded.
  * @param connection the connection instance that was recovered.
  */
 - (void)recoveredConnection:(RMQConnection *)connection;

--- a/RMQClient/RMQURI.m
+++ b/RMQClient/RMQURI.m
@@ -68,7 +68,7 @@
     if (![self isValidScheme:components.scheme]) {
         *error = [NSError errorWithDomain:RMQErrorDomain
                                      code:RMQErrorInvalidScheme
-                                 userInfo:@{NSLocalizedDescriptionKey: NSLocalizedString(@"Connection URI must use amqp or amqps schema (example: amqp://bus.megacorp.internal:5766), learn more at http://bit.ly/ks8MXK", nil)}];
+                                 userInfo:@{NSLocalizedDescriptionKey: NSLocalizedString(@"Connection URI must use amqp or amqps schema (example: amqp://bus.megacorp.internal:5766), learn more at https://bit.ly/ks8MXK", nil)}];
         return nil;
     }
 

--- a/RMQClientIntegrationTests/Info.plist
+++ b/RMQClientIntegrationTests/Info.plist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>CFBundleDevelopmentRegion</key>

--- a/RMQClientTests/AtomicInteger.swift
+++ b/RMQClientTests/AtomicInteger.swift
@@ -20,7 +20,7 @@
 // ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
 //
-// For more information, please refer to <http://unlicense.org/>
+// For more information, please refer to <https://unlicense.org/>
 
 import Foundation
 

--- a/RMQClientTests/Info.plist
+++ b/RMQClientTests/Info.plist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>CFBundleDevelopmentRegion</key>

--- a/RMQClientTests/MethodFixtures.swift
+++ b/RMQClientTests/MethodFixtures.swift
@@ -176,7 +176,7 @@ class MethodFixtures {
             "capabilities": RMQTable(dict),
             "cluster_name": RMQLongstr("rabbit@myapp.cfapps.pez.pivotal.io"),
             "copyright": RMQLongstr("Copyright (C) 2007-2019 Pivotal Software, Inc."),
-            "information": RMQLongstr("Licensed under the MPL.  See http://www.rabbitmq.com/"),
+            "information": RMQLongstr("Licensed under the MPL.  See https://www.rabbitmq.com/"),
             "platform": RMQLongstr("Erlang/OTP"),
             "product": RMQLongstr("RabbitMQ"),
             "version": RMQLongstr("3.7.10")

--- a/RMQClientTests/RMQHTTP.swift
+++ b/RMQClientTests/RMQHTTP.swift
@@ -52,7 +52,7 @@
 import Foundation
 
 class RMQHTTP {
-    static let testEndpoint = "http://guest:guest@127.0.0.1:15672/api"
+    static let testEndpoint = "https://guest:guest@127.0.0.1:15672/api"
 
     var uri: String
 

--- a/RMQClientTests/RMQURIParseTest.swift
+++ b/RMQClientTests/RMQURIParseTest.swift
@@ -53,7 +53,7 @@ import XCTest
 
 class RMQURIParseTest: XCTestCase {
     func testNonAMQPSchemesNotAllowed() {
-        XCTAssertThrowsError(try RMQURI.parse("http://dev.rabbitmq.com")) { error in
+        XCTAssertThrowsError(try RMQURI.parse("https://dev.rabbitmq.com")) { error in
             do {
                 XCTAssertEqual(
                     RMQError.invalidScheme.rawValue,

--- a/docker/apt/sources.list.d/bintray.rabbitmq.list
+++ b/docker/apt/sources.list.d/bintray.rabbitmq.list
@@ -1,2 +1,2 @@
-deb http://dl.bintray.com/rabbitmq-erlang/debian bionic erlang
-deb http://dl.bintray.com/rabbitmq/debian bionic main
+deb https://dl.bintray.com/rabbitmq-erlang/debian bionic erlang
+deb https://dl.bintray.com/rabbitmq/debian bionic main


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://rubybunny.info (200) with 2 occurrences could not be migrated:  
   ([https](https://rubybunny.info) result AnnotatedConnectException).
* http://scooterlabs.com (200) with 2 occurrences could not be migrated:  
   ([https](https://scooterlabs.com) result AnnotatedConnectException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://dev.rabbitmq.com (UnknownHostException) with 1 occurrences migrated to:  
  https://dev.rabbitmq.com ([https](https://dev.rabbitmq.com) result UnknownHostException).
* http://guest:guest@127.0.0.1:15672/api (UnknownHostException) with 1 occurrences migrated to:  
  https://guest:guest@127.0.0.1:15672/api ([https](https://guest:guest@127.0.0.1:15672/api) result UnknownHostException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://unlicense.org/ with 1 occurrences migrated to:  
  https://unlicense.org/ ([https](https://unlicense.org/) result 200).
* http://www.apple.com/DTDs/PropertyList-1.0.dtd with 6 occurrences migrated to:  
  https://www.apple.com/DTDs/PropertyList-1.0.dtd ([https](https://www.apple.com/DTDs/PropertyList-1.0.dtd) result 200).
* http://www.rabbitmq.com/ with 1 occurrences migrated to:  
  https://www.rabbitmq.com/ ([https](https://www.rabbitmq.com/) result 200).
* http://www.rabbitmq.com/api-guide.html with 3 occurrences migrated to:  
  https://www.rabbitmq.com/api-guide.html ([https](https://www.rabbitmq.com/api-guide.html) result 200).
* http://www.rabbitmq.com/getstarted.html with 2 occurrences migrated to:  
  https://www.rabbitmq.com/getstarted.html ([https](https://www.rabbitmq.com/getstarted.html) result 200).
* http://www.rabbitmq.com/specification.html with 1 occurrences migrated to:  
  https://www.rabbitmq.com/specification.html ([https](https://www.rabbitmq.com/specification.html) result 200).
* http://bit.ly/ks8MXK with 1 occurrences migrated to:  
  https://bit.ly/ks8MXK ([https](https://bit.ly/ks8MXK) result 301).
* http://contributor-covenant.org with 1 occurrences migrated to:  
  https://contributor-covenant.org ([https](https://contributor-covenant.org) result 301).
* http://contributor-covenant.org/version/1/3/0/ with 1 occurrences migrated to:  
  https://contributor-covenant.org/version/1/3/0/ ([https](https://contributor-covenant.org/version/1/3/0/) result 301).
* http://dl.bintray.com/rabbitmq-erlang/debian with 1 occurrences migrated to:  
  https://dl.bintray.com/rabbitmq-erlang/debian ([https](https://dl.bintray.com/rabbitmq-erlang/debian) result 301).
* http://dl.bintray.com/rabbitmq/debian with 1 occurrences migrated to:  
  https://dl.bintray.com/rabbitmq/debian ([https](https://dl.bintray.com/rabbitmq/debian) result 301).
* http://www.mozilla.org/MPL/ with 1 occurrences migrated to:  
  https://www.mozilla.org/MPL/ ([https](https://www.mozilla.org/MPL/) result 301).