### PR TITLE
Avoid RMQConnection leaks by adopting weak refs (on behalf of @BarryDuggan)

### DIFF
--- a/RMQClient/RMQAllocatedChannel.m
+++ b/RMQClient/RMQAllocatedChannel.m
@@ -49,7 +49,7 @@
 @interface RMQAllocatedChannel ()
 @property (nonatomic, copy, readwrite) NSNumber *channelNumber;
 @property (nonatomic, readwrite) NSNumber *contentBodySize;
-@property (nonatomic, readwrite) id <RMQDispatcher> dispatcher;
+@property (nonatomic, weak, readwrite) id <RMQDispatcher> dispatcher;
 @property (nonatomic, readwrite) NSMutableDictionary *consumers;
 @property (nonatomic, readwrite) NSMutableDictionary *exchanges;
 @property (nonatomic, readwrite) NSMutableDictionary *exchangeBindings;
@@ -58,9 +58,9 @@
 @property (nonatomic, readwrite) id<RMQConfirmations> confirmations;
 @property (nonatomic, readwrite) NSNumber *prefetchCountPerConsumer;
 @property (nonatomic, readwrite) NSNumber *prefetchCountPerChannel;
-@property (nonatomic, readwrite) id<RMQConnectionDelegate> delegate;
+@property (nonatomic, weak, readwrite) id<RMQConnectionDelegate> delegate;
 @property (nonatomic, readwrite) id<RMQNameGenerator> nameGenerator;
-@property (nonatomic, readwrite) id<RMQChannelAllocator> allocator;
+@property (nonatomic, weak, readwrite) id<RMQChannelAllocator> allocator;
 @end
 
 @implementation RMQAllocatedChannel

--- a/RMQClient/RMQConnection.m
+++ b/RMQClient/RMQConnection.m
@@ -60,22 +60,19 @@
 #import <RMQFrame.h>
 #import <RMQProcessInfoNameGenerator.h>
 
-@interface RMQConnection ()
-@property (strong, nonatomic, readwrite) id <RMQTransport> transport;
-@property (nonatomic, readwrite) RMQReader *reader;
-@property (nonatomic, readwrite) id <RMQChannelAllocator> channelAllocator;
-@property (nonatomic, readwrite) id <RMQFrameHandler> frameHandler;
+@property (weak, nonatomic, readwrite) id <RMQTransport> transport;
+@property (nonatomic, weak, readwrite) RMQReader *reader;
+@property (nonatomic, weak, readwrite) id <RMQChannelAllocator> channelAllocator;
+@property (nonatomic, weak, readwrite) id <RMQFrameHandler> frameHandler;
 @property (nonatomic, readwrite) id<RMQLocalSerialQueue> commandQueue;
 @property (nonatomic, readwrite) id<RMQWaiterFactory> waiterFactory;
-@property (nonatomic, readwrite) id<RMQHeartbeatSender> heartbeatSender;
-@property (nonatomic, weak, readwrite) id<RMQConnectionDelegate> delegate;
+@property (nonatomic, weak, readwrite) id<RMQHeartbeatSender> heartbeatSender;
 @property (nonatomic, readwrite) id <RMQChannel> channelZero;
-@property (nonatomic, readwrite) RMQConnectionConfig *config;
+@property (nonatomic, weak, readwrite) RMQConnectionConfig *config;
 @property (nonatomic, readwrite) NSMutableDictionary *userChannels;
 @property (nonatomic, readwrite) NSNumber *frameMax;
 @property (nonatomic, readwrite) BOOL handshakeComplete;
 @property (nonatomic, readwrite) NSNumber *handshakeTimeout;
-@end
 
 __attribute__((constructor))
 static void RMQInitConnectionConfigDefaults() {


### PR DESCRIPTION
for some important dependencies of allocated channels and
RMQConnection itself.

In this client, RMQConnection auto-allocates a channel for
the purpose of special "channel zero" (system communication
in the protocol) purposes, and that leads to a loop
of strong references that prevent RMQConnection instances
from being released.

Contributed by @BarryDuggan in #194.
