### PR TITLE
Avoid RMQConnection leaks by adopting weak refs, take 3

### DIFF
--- a/MemoryTest/AppDelegate.swift
+++ b/MemoryTest/AppDelegate.swift
@@ -1,0 +1,37 @@
+//
+//  AppDelegate.swift
+//  MemoryTest
+//
+//  Created by Barry Duggan on 01/04/2022.
+//  Copyright © 2022 VMware. All rights reserved.
+//
+
+import UIKit
+
+@main
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+
+
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        // Override point for customization after application launch.
+        return true
+    }
+
+    // MARK: UISceneSession Lifecycle
+
+    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+        // Called when a new scene session is being created.
+        // Use this method to select a configuration to create the new scene with.
+        return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+    }
+
+    func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
+        // Called when the user discards a scene session.
+        // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
+        // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
+    }
+
+
+}
+

--- a/MemoryTest/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/MemoryTest/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/MemoryTest/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/MemoryTest/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,98 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "83.5x83.5"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/MemoryTest/Assets.xcassets/Contents.json
+++ b/MemoryTest/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/MemoryTest/Base.lproj/LaunchScreen.storyboard
+++ b/MemoryTest/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/MemoryTest/Base.lproj/Main.storyboard
+++ b/MemoryTest/Base.lproj/Main.storyboard
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="MemoryTest" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="UmE-Cc-1KD">
+                                <rect key="frame" x="162" y="270" width="148" height="31"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="plain" title="Button"/>
+                                <connections>
+                                    <action selector="clearConnection" destination="BYZ-38-t0r" eventType="touchUpInside" id="Nbh-hI-wwa"/>
+                                </connections>
+                            </button>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="44.927536231884062" y="83.705357142857139"/>
+        </scene>
+    </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/MemoryTest/Info.plist
+++ b/MemoryTest/Info.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/MemoryTest/SceneDelegate.swift
+++ b/MemoryTest/SceneDelegate.swift
@@ -1,0 +1,53 @@
+//
+//  SceneDelegate.swift
+//  MemoryTest
+//
+//  Created by Barry Duggan on 01/04/2022.
+//  Copyright © 2022 VMware. All rights reserved.
+//
+
+import UIKit
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+
+    var window: UIWindow?
+
+
+    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+        // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
+        // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
+        // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
+        guard let _ = (scene as? UIWindowScene) else { return }
+    }
+
+    func sceneDidDisconnect(_ scene: UIScene) {
+        // Called as the scene is being released by the system.
+        // This occurs shortly after the scene enters the background, or when its session is discarded.
+        // Release any resources associated with this scene that can be re-created the next time the scene connects.
+        // The scene may re-connect later, as its session was not necessarily discarded (see `application:didDiscardSceneSessions` instead).
+    }
+
+    func sceneDidBecomeActive(_ scene: UIScene) {
+        // Called when the scene has moved from an inactive state to an active state.
+        // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
+    }
+
+    func sceneWillResignActive(_ scene: UIScene) {
+        // Called when the scene will move from an active state to an inactive state.
+        // This may occur due to temporary interruptions (ex. an incoming phone call).
+    }
+
+    func sceneWillEnterForeground(_ scene: UIScene) {
+        // Called as the scene transitions from the background to the foreground.
+        // Use this method to undo the changes made on entering the background.
+    }
+
+    func sceneDidEnterBackground(_ scene: UIScene) {
+        // Called as the scene transitions from the foreground to the background.
+        // Use this method to save data, release shared resources, and store enough scene-specific state information
+        // to restore the scene back to its current state.
+    }
+
+
+}
+

--- a/MemoryTest/ViewController.swift
+++ b/MemoryTest/ViewController.swift
@@ -9,7 +9,7 @@
 import UIKit
 import RMQClient
 class ViewController: UIViewController {
-    let amqp = "my-server"
+    let amqp = ""
 
     var connection: RMQConnection?
     override func viewDidLoad() {

--- a/MemoryTest/ViewController.swift
+++ b/MemoryTest/ViewController.swift
@@ -9,13 +9,13 @@
 import UIKit
 import RMQClient
 class ViewController: UIViewController {
-    let amqp = "amqps://tofs_ios_qa:jIShN8QDsLkxUwxS@tofs-us-west-1-rabbitmq-qa.tycodiy.com:443"
+    let amqp = "my-server"
 
     var connection: RMQConnection?
     override func viewDidLoad() {
         super.viewDidLoad()
         // Do any additional setup after loading the view.
-        connection = RMQConnection(uri: "amqps://tofs_ios_qa:jIShN8QDsLkxUwxS@tofs-us-west-1-rabbitmq-qa.tycodiy.com:443", delegate: self)
+        connection = RMQConnection(uri: amqp, delegate: self)
          connection?.start({
              print("Connected")
          })
@@ -25,13 +25,6 @@ class ViewController: UIViewController {
         connection?.close()
         connection = nil
         print("CLOSED")
-        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 2, execute: {[weak self] in
-            self?.connection = RMQConnection(uri: "amqps://tofs_ios_qa:jIShN8QDsLkxUwxS@tofs-us-west-1-rabbitmq-qa.tycodiy.com:443", delegate: self)
-            self?.connection?.start({
-                 print("Connected")
-             })
-            
-        })
     }
 
 

--- a/MemoryTest/ViewController.swift
+++ b/MemoryTest/ViewController.swift
@@ -1,0 +1,71 @@
+//
+//  ViewController.swift
+//  MemoryTest
+//
+//  Created by Barry Duggan on 01/04/2022.
+//  Copyright © 2022 VMware. All rights reserved.
+//
+
+import UIKit
+import RMQClient
+class ViewController: UIViewController {
+    let amqp = "amqps://tofs_ios_qa:jIShN8QDsLkxUwxS@tofs-us-west-1-rabbitmq-qa.tycodiy.com:443"
+
+    var connection: RMQConnection?
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        // Do any additional setup after loading the view.
+        connection = RMQConnection(uri: "amqps://tofs_ios_qa:jIShN8QDsLkxUwxS@tofs-us-west-1-rabbitmq-qa.tycodiy.com:443", delegate: self)
+         connection?.start({
+             print(self)
+         })
+    }
+    
+    @IBAction func clearConnection() {
+        connection = nil
+    }
+
+
+}
+
+extension ViewController: RMQConnectionDelegate {
+    /// @brief Called when a socket cannot be opened, or when AMQP handshaking times out for some reason.
+    func connection(_ connection: RMQConnection!, failedToConnectWithError error: Error!) {
+        print(self)
+        print("RABBIT: failedToConnectWithError")
+    }
+
+    /// @brief Called when a connection disconnects for any reason
+    func connection(_ connection: RMQConnection!, disconnectedWithError error: Error!) {
+        print(self)
+        print("RABBIT: disconnectedWithError")
+    }
+
+    /// @brief Called before the configured http://www.rabbitmq.com/api-guide.html#recovery automatic connection recovery</a> sleep.
+    func willStartRecovery(with connection: RMQConnection!) {
+        print(self)
+        print("RABBIT: willStartRecovery")
+    }
+
+    /// @brief Called after the configured http://www.rabbitmq.com/api-guide.html#recovery automatic connection recovery</a> sleep.
+    func startingRecovery(with connection: RMQConnection!) {
+        print(self)
+        print("RABBIT: startingRecovery")
+    }
+
+    /*!
+     * @brief Called when http://www.rabbitmq.com/api-guide.html#recovery automatic connection recovery</a> has succeeded.
+     * @param RMQConnection the connection instance that was recovered.
+     */
+    func recoveredConnection(_ connection: RMQConnection!) {
+        print(self)
+        print("RABBIT: recoveredConnection")
+
+    }
+
+    /// @brief Called with any channel-level AMQP exception.
+    func channel(_ channel: RMQChannel!, error: Error!) {
+        print(self)
+        print("RABBIT: Channel Error")
+    }
+}

--- a/MemoryTest/ViewController.swift
+++ b/MemoryTest/ViewController.swift
@@ -22,7 +22,9 @@ class ViewController: UIViewController {
     }
     
     @IBAction func clearConnection() {
+        connection?.close()
         connection = nil
+        print("CLOSED")
     }
 
 

--- a/MemoryTest/ViewController.swift
+++ b/MemoryTest/ViewController.swift
@@ -17,7 +17,7 @@ class ViewController: UIViewController {
         // Do any additional setup after loading the view.
         connection = RMQConnection(uri: "amqps://tofs_ios_qa:jIShN8QDsLkxUwxS@tofs-us-west-1-rabbitmq-qa.tycodiy.com:443", delegate: self)
          connection?.start({
-             print(self)
+             print("Connected")
          })
     }
     
@@ -25,6 +25,13 @@ class ViewController: UIViewController {
         connection?.close()
         connection = nil
         print("CLOSED")
+        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 2, execute: {[weak self] in
+            self?.connection = RMQConnection(uri: "amqps://tofs_ios_qa:jIShN8QDsLkxUwxS@tofs-us-west-1-rabbitmq-qa.tycodiy.com:443", delegate: self)
+            self?.connection?.start({
+                 print("Connected")
+             })
+            
+        })
     }
 
 

--- a/MemoryTestTests/MemoryTestTests.swift
+++ b/MemoryTestTests/MemoryTestTests.swift
@@ -1,0 +1,34 @@
+//
+//  MemoryTestTests.swift
+//  MemoryTestTests
+//
+//  Created by Barry Duggan on 01/04/2022.
+//  Copyright © 2022 VMware. All rights reserved.
+//
+
+import XCTest
+@testable import MemoryTest
+
+class MemoryTestTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+
+    func testPerformanceExample() throws {
+        // This is an example of a performance test case.
+        self.measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+
+}

--- a/MemoryTestUITests/MemoryTestUITests.swift
+++ b/MemoryTestUITests/MemoryTestUITests.swift
@@ -1,0 +1,43 @@
+//
+//  MemoryTestUITests.swift
+//  MemoryTestUITests
+//
+//  Created by Barry Duggan on 01/04/2022.
+//  Copyright © 2022 VMware. All rights reserved.
+//
+
+import XCTest
+
+class MemoryTestUITests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+
+        // In UI tests it is usually best to stop immediately when a failure occurs.
+        continueAfterFailure = false
+
+        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // UI tests must launch the application that they test.
+        let app = XCUIApplication()
+        app.launch()
+
+        // Use recording to get started writing UI tests.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+
+    func testLaunchPerformance() throws {
+        if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 7.0, *) {
+            // This measures how long it takes to launch your application.
+            measure(metrics: [XCTApplicationLaunchMetric()]) {
+                XCUIApplication().launch()
+            }
+        }
+    }
+}

--- a/MemoryTestUITests/MemoryTestUITestsLaunchTests.swift
+++ b/MemoryTestUITests/MemoryTestUITestsLaunchTests.swift
@@ -1,0 +1,33 @@
+//
+//  MemoryTestUITestsLaunchTests.swift
+//  MemoryTestUITests
+//
+//  Created by Barry Duggan on 01/04/2022.
+//  Copyright © 2022 VMware. All rights reserved.
+//
+
+import XCTest
+
+class MemoryTestUITestsLaunchTests: XCTestCase {
+
+    override class var runsForEachTargetApplicationUIConfiguration: Bool {
+        true
+    }
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    func testLaunch() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        // Insert steps here to perform after app launch but before taking a screenshot,
+        // such as logging into a test account or navigating somewhere in the app
+
+        let attachment = XCTAttachment(screenshot: app.screenshot())
+        attachment.name = "Launch Screen"
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+}

--- a/RMQClient.xcodeproj/project.pbxproj
+++ b/RMQClient.xcodeproj/project.pbxproj
@@ -8,6 +8,16 @@
 
 /* Begin PBXBuildFile section */
 		1029A0E22087A97E00C72924 /* ConnectionDeadlockTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1029A0E12087A97E00C72924 /* ConnectionDeadlockTests.swift */; };
+		4DF6E43927F6E90700C43208 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DF6E43827F6E90700C43208 /* AppDelegate.swift */; };
+		4DF6E43B27F6E90700C43208 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DF6E43A27F6E90700C43208 /* SceneDelegate.swift */; };
+		4DF6E43D27F6E90700C43208 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DF6E43C27F6E90700C43208 /* ViewController.swift */; };
+		4DF6E44027F6E90700C43208 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 4DF6E43E27F6E90700C43208 /* Main.storyboard */; };
+		4DF6E44227F6E90900C43208 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4DF6E44127F6E90900C43208 /* Assets.xcassets */; };
+		4DF6E44527F6E90900C43208 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 4DF6E44327F6E90900C43208 /* LaunchScreen.storyboard */; };
+		4DF6E45027F6E90A00C43208 /* MemoryTestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DF6E44F27F6E90A00C43208 /* MemoryTestTests.swift */; };
+		4DF6E45A27F6E90A00C43208 /* MemoryTestUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DF6E45927F6E90A00C43208 /* MemoryTestUITests.swift */; };
+		4DF6E45C27F6E90A00C43208 /* MemoryTestUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DF6E45B27F6E90A00C43208 /* MemoryTestUITestsLaunchTests.swift */; };
+		4DF6E46D27F6E98100C43208 /* RMQClient.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AEE7FE911C3BCA6000DF8C4F /* RMQClient.framework */; };
 		70311B0B21ED538600AE1804 /* RMQConnectionDefaults.h in Headers */ = {isa = PBXBuildFile; fileRef = 70311B0A21ED538600AE1804 /* RMQConnectionDefaults.h */; };
 		70338A2421FBAA7C00C9069D /* TLSConnectionIntegrationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70338A2321FBAA7C00C9069D /* TLSConnectionIntegrationTest.swift */; };
 		705359A921D174A400CF6456 /* TestCertificates in Resources */ = {isa = PBXBuildFile; fileRef = 705359A821D174A400CF6456 /* TestCertificates */; };
@@ -218,6 +228,20 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		4DF6E44C27F6E90A00C43208 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = AEE7FE881C3BCA6000DF8C4F /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 4DF6E43527F6E90700C43208;
+			remoteInfo = MemoryTest;
+		};
+		4DF6E45627F6E90A00C43208 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = AEE7FE881C3BCA6000DF8C4F /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 4DF6E43527F6E90700C43208;
+			remoteInfo = MemoryTest;
+		};
 		AEA45EDD1C440FE400FE1F62 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = AEE7FE881C3BCA6000DF8C4F /* Project object */;
@@ -236,6 +260,19 @@
 
 /* Begin PBXFileReference section */
 		1029A0E12087A97E00C72924 /* ConnectionDeadlockTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConnectionDeadlockTests.swift; sourceTree = "<group>"; };
+		4DF6E43627F6E90700C43208 /* MemoryTest.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MemoryTest.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		4DF6E43827F6E90700C43208 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		4DF6E43A27F6E90700C43208 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
+		4DF6E43C27F6E90700C43208 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		4DF6E43F27F6E90700C43208 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		4DF6E44127F6E90900C43208 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		4DF6E44427F6E90900C43208 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		4DF6E44627F6E90900C43208 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		4DF6E44B27F6E90A00C43208 /* MemoryTestTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MemoryTestTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		4DF6E44F27F6E90A00C43208 /* MemoryTestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryTestTests.swift; sourceTree = "<group>"; };
+		4DF6E45527F6E90A00C43208 /* MemoryTestUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MemoryTestUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		4DF6E45927F6E90A00C43208 /* MemoryTestUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryTestUITests.swift; sourceTree = "<group>"; };
+		4DF6E45B27F6E90A00C43208 /* MemoryTestUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryTestUITestsLaunchTests.swift; sourceTree = "<group>"; };
 		70311B0A21ED538600AE1804 /* RMQConnectionDefaults.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RMQConnectionDefaults.h; sourceTree = "<group>"; };
 		70338A2321FBAA7C00C9069D /* TLSConnectionIntegrationTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TLSConnectionIntegrationTest.swift; sourceTree = "<group>"; };
 		705359A821D174A400CF6456 /* TestCertificates */ = {isa = PBXFileReference; lastKnownFileType = folder; path = TestCertificates; sourceTree = SOURCE_ROOT; };
@@ -437,6 +474,28 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		4DF6E43327F6E90700C43208 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4DF6E46D27F6E98100C43208 /* RMQClient.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4DF6E44827F6E90A00C43208 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4DF6E45227F6E90A00C43208 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		AEA45ED41C440FE400FE1F62 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -463,6 +522,44 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		4DF6E43727F6E90700C43208 /* MemoryTest */ = {
+			isa = PBXGroup;
+			children = (
+				4DF6E43827F6E90700C43208 /* AppDelegate.swift */,
+				4DF6E43A27F6E90700C43208 /* SceneDelegate.swift */,
+				4DF6E43C27F6E90700C43208 /* ViewController.swift */,
+				4DF6E43E27F6E90700C43208 /* Main.storyboard */,
+				4DF6E44127F6E90900C43208 /* Assets.xcassets */,
+				4DF6E44327F6E90900C43208 /* LaunchScreen.storyboard */,
+				4DF6E44627F6E90900C43208 /* Info.plist */,
+			);
+			path = MemoryTest;
+			sourceTree = "<group>";
+		};
+		4DF6E44E27F6E90A00C43208 /* MemoryTestTests */ = {
+			isa = PBXGroup;
+			children = (
+				4DF6E44F27F6E90A00C43208 /* MemoryTestTests.swift */,
+			);
+			path = MemoryTestTests;
+			sourceTree = "<group>";
+		};
+		4DF6E45827F6E90A00C43208 /* MemoryTestUITests */ = {
+			isa = PBXGroup;
+			children = (
+				4DF6E45927F6E90A00C43208 /* MemoryTestUITests.swift */,
+				4DF6E45B27F6E90A00C43208 /* MemoryTestUITestsLaunchTests.swift */,
+			);
+			path = MemoryTestUITests;
+			sourceTree = "<group>";
+		};
+		4DF6E46C27F6E98100C43208 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		70970AD521E68D6100E9CC8B /* Helpers */ = {
 			isa = PBXGroup;
 			children = (
@@ -775,7 +872,11 @@
 				AEE7FE931C3BCA6000DF8C4F /* RMQClient */,
 				AEE7FE9F1C3BCA6000DF8C4F /* RMQClientTests */,
 				AEA45ED81C440FE400FE1F62 /* RMQClientIntegrationTests */,
+				4DF6E43727F6E90700C43208 /* MemoryTest */,
+				4DF6E44E27F6E90A00C43208 /* MemoryTestTests */,
+				4DF6E45827F6E90A00C43208 /* MemoryTestUITests */,
 				AEE7FE921C3BCA6000DF8C4F /* Products */,
+				4DF6E46C27F6E98100C43208 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -785,6 +886,9 @@
 				AEE7FE911C3BCA6000DF8C4F /* RMQClient.framework */,
 				AEE7FE9B1C3BCA6000DF8C4F /* RMQClientTests.xctest */,
 				AEA45ED71C440FE400FE1F62 /* RMQClientIntegrationTests.xctest */,
+				4DF6E43627F6E90700C43208 /* MemoryTest.app */,
+				4DF6E44B27F6E90A00C43208 /* MemoryTestTests.xctest */,
+				4DF6E45527F6E90A00C43208 /* MemoryTestUITests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -963,6 +1067,59 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
+		4DF6E43527F6E90700C43208 /* MemoryTest */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 4DF6E46927F6E90A00C43208 /* Build configuration list for PBXNativeTarget "MemoryTest" */;
+			buildPhases = (
+				4DF6E43227F6E90700C43208 /* Sources */,
+				4DF6E43327F6E90700C43208 /* Frameworks */,
+				4DF6E43427F6E90700C43208 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = MemoryTest;
+			productName = MemoryTest;
+			productReference = 4DF6E43627F6E90700C43208 /* MemoryTest.app */;
+			productType = "com.apple.product-type.application";
+		};
+		4DF6E44A27F6E90A00C43208 /* MemoryTestTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 4DF6E46A27F6E90A00C43208 /* Build configuration list for PBXNativeTarget "MemoryTestTests" */;
+			buildPhases = (
+				4DF6E44727F6E90A00C43208 /* Sources */,
+				4DF6E44827F6E90A00C43208 /* Frameworks */,
+				4DF6E44927F6E90A00C43208 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				4DF6E44D27F6E90A00C43208 /* PBXTargetDependency */,
+			);
+			name = MemoryTestTests;
+			productName = MemoryTestTests;
+			productReference = 4DF6E44B27F6E90A00C43208 /* MemoryTestTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		4DF6E45427F6E90A00C43208 /* MemoryTestUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 4DF6E46B27F6E90A00C43208 /* Build configuration list for PBXNativeTarget "MemoryTestUITests" */;
+			buildPhases = (
+				4DF6E45127F6E90A00C43208 /* Sources */,
+				4DF6E45227F6E90A00C43208 /* Frameworks */,
+				4DF6E45327F6E90A00C43208 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				4DF6E45727F6E90A00C43208 /* PBXTargetDependency */,
+			);
+			name = MemoryTestUITests;
+			productName = MemoryTestUITests;
+			productReference = 4DF6E45527F6E90A00C43208 /* MemoryTestUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
 		AEA45ED61C440FE400FE1F62 /* RMQClientIntegrationTests */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = AEA45EDF1C440FE400FE1F62 /* Build configuration list for PBXNativeTarget "RMQClientIntegrationTests" */;
@@ -1026,10 +1183,21 @@
 		AEE7FE881C3BCA6000DF8C4F /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 0700;
+				LastSwiftUpdateCheck = 1300;
 				LastUpgradeCheck = 1330;
 				ORGANIZATIONNAME = VMware;
 				TargetAttributes = {
+					4DF6E43527F6E90700C43208 = {
+						CreatedOnToolsVersion = 13.0;
+					};
+					4DF6E44A27F6E90A00C43208 = {
+						CreatedOnToolsVersion = 13.0;
+						TestTargetID = 4DF6E43527F6E90700C43208;
+					};
+					4DF6E45427F6E90A00C43208 = {
+						CreatedOnToolsVersion = 13.0;
+						TestTargetID = 4DF6E43527F6E90700C43208;
+					};
 					AEA45ED61C440FE400FE1F62 = {
 						CreatedOnToolsVersion = 7.0;
 						LastSwiftMigration = 1020;
@@ -1059,11 +1227,38 @@
 				AEE7FE901C3BCA6000DF8C4F /* RMQClient */,
 				AEE7FE9A1C3BCA6000DF8C4F /* RMQClientTests */,
 				AEA45ED61C440FE400FE1F62 /* RMQClientIntegrationTests */,
+				4DF6E43527F6E90700C43208 /* MemoryTest */,
+				4DF6E44A27F6E90A00C43208 /* MemoryTestTests */,
+				4DF6E45427F6E90A00C43208 /* MemoryTestUITests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		4DF6E43427F6E90700C43208 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4DF6E44527F6E90900C43208 /* LaunchScreen.storyboard in Resources */,
+				4DF6E44227F6E90900C43208 /* Assets.xcassets in Resources */,
+				4DF6E44027F6E90700C43208 /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4DF6E44927F6E90A00C43208 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4DF6E45327F6E90A00C43208 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		AEA45ED51C440FE400FE1F62 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -1142,6 +1337,33 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		4DF6E43227F6E90700C43208 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4DF6E43D27F6E90700C43208 /* ViewController.swift in Sources */,
+				4DF6E43927F6E90700C43208 /* AppDelegate.swift in Sources */,
+				4DF6E43B27F6E90700C43208 /* SceneDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4DF6E44727F6E90A00C43208 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4DF6E45027F6E90A00C43208 /* MemoryTestTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4DF6E45127F6E90A00C43208 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4DF6E45A27F6E90A00C43208 /* MemoryTestUITests.swift in Sources */,
+				4DF6E45C27F6E90A00C43208 /* MemoryTestUITestsLaunchTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		AEA45ED31C440FE400FE1F62 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -1305,6 +1527,16 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		4DF6E44D27F6E90A00C43208 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 4DF6E43527F6E90700C43208 /* MemoryTest */;
+			targetProxy = 4DF6E44C27F6E90A00C43208 /* PBXContainerItemProxy */;
+		};
+		4DF6E45727F6E90A00C43208 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 4DF6E43527F6E90700C43208 /* MemoryTest */;
+			targetProxy = 4DF6E45627F6E90A00C43208 /* PBXContainerItemProxy */;
+		};
 		AEA45EDE1C440FE400FE1F62 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = AEE7FE901C3BCA6000DF8C4F /* RMQClient */;
@@ -1317,7 +1549,467 @@
 		};
 /* End PBXTargetDependency section */
 
+/* Begin PBXVariantGroup section */
+		4DF6E43E27F6E90700C43208 /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				4DF6E43F27F6E90700C43208 /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		4DF6E44327F6E90900C43208 /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				4DF6E44427F6E90900C43208 /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
 /* Begin XCBuildConfiguration section */
+		4DF6E45D27F6E90A00C43208 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = UL386KE9LP;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = MemoryTest/Info.plist;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+				INFOPLIST_KEY_UIMainStoryboardFile = Main;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.jci.MemoryTest;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		4DF6E45E27F6E90A00C43208 /* Test without TLS */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = UL386KE9LP;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = MemoryTest/Info.plist;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+				INFOPLIST_KEY_UIMainStoryboardFile = Main;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.jci.MemoryTest;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Test without TLS";
+		};
+		4DF6E45F27F6E90A00C43208 /* Test with TLS */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = UL386KE9LP;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = MemoryTest/Info.plist;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+				INFOPLIST_KEY_UIMainStoryboardFile = Main;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.jci.MemoryTest;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Test with TLS";
+		};
+		4DF6E46027F6E90A00C43208 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = UL386KE9LP;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = MemoryTest/Info.plist;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+				INFOPLIST_KEY_UIMainStoryboardFile = Main;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.jci.MemoryTest;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		4DF6E46127F6E90A00C43208 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = UL386KE9LP;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.jci.MemoryTestTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/MemoryTest.app/MemoryTest";
+			};
+			name = Debug;
+		};
+		4DF6E46227F6E90A00C43208 /* Test without TLS */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = UL386KE9LP;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.jci.MemoryTestTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/MemoryTest.app/MemoryTest";
+			};
+			name = "Test without TLS";
+		};
+		4DF6E46327F6E90A00C43208 /* Test with TLS */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = UL386KE9LP;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.jci.MemoryTestTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/MemoryTest.app/MemoryTest";
+			};
+			name = "Test with TLS";
+		};
+		4DF6E46427F6E90A00C43208 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = UL386KE9LP;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.jci.MemoryTestTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/MemoryTest.app/MemoryTest";
+			};
+			name = Release;
+		};
+		4DF6E46527F6E90A00C43208 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = UL386KE9LP;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.jci.MemoryTestUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = MemoryTest;
+			};
+			name = Debug;
+		};
+		4DF6E46627F6E90A00C43208 /* Test without TLS */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = UL386KE9LP;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.jci.MemoryTestUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = MemoryTest;
+			};
+			name = "Test without TLS";
+		};
+		4DF6E46727F6E90A00C43208 /* Test with TLS */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = UL386KE9LP;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.jci.MemoryTestUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = MemoryTest;
+			};
+			name = "Test with TLS";
+		};
+		4DF6E46827F6E90A00C43208 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = UL386KE9LP;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.jci.MemoryTestUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = MemoryTest;
+			};
+			name = Release;
+		};
 		70338A2721FBBB0D00C9069D /* Test without TLS */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -1894,6 +2586,39 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		4DF6E46927F6E90A00C43208 /* Build configuration list for PBXNativeTarget "MemoryTest" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4DF6E45D27F6E90A00C43208 /* Debug */,
+				4DF6E45E27F6E90A00C43208 /* Test without TLS */,
+				4DF6E45F27F6E90A00C43208 /* Test with TLS */,
+				4DF6E46027F6E90A00C43208 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		4DF6E46A27F6E90A00C43208 /* Build configuration list for PBXNativeTarget "MemoryTestTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4DF6E46127F6E90A00C43208 /* Debug */,
+				4DF6E46227F6E90A00C43208 /* Test without TLS */,
+				4DF6E46327F6E90A00C43208 /* Test with TLS */,
+				4DF6E46427F6E90A00C43208 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		4DF6E46B27F6E90A00C43208 /* Build configuration list for PBXNativeTarget "MemoryTestUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4DF6E46527F6E90A00C43208 /* Debug */,
+				4DF6E46627F6E90A00C43208 /* Test without TLS */,
+				4DF6E46727F6E90A00C43208 /* Test with TLS */,
+				4DF6E46827F6E90A00C43208 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		AEA45EDF1C440FE400FE1F62 /* Build configuration list for PBXNativeTarget "RMQClientIntegrationTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/RMQClient.xcodeproj/xcshareddata/xcschemes/MemoryTest.xcscheme
+++ b/RMQClient.xcodeproj/xcshareddata/xcschemes/MemoryTest.xcscheme
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1300"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4DF6E43527F6E90700C43208"
+               BuildableName = "MemoryTest.app"
+               BlueprintName = "MemoryTest"
+               ReferencedContainer = "container:RMQClient.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4DF6E43527F6E90700C43208"
+            BuildableName = "MemoryTest.app"
+            BlueprintName = "MemoryTest"
+            ReferencedContainer = "container:RMQClient.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+         <AdditionalOption
+            key = "MallocStackLogging"
+            value = ""
+            isEnabled = "YES">
+         </AdditionalOption>
+         <AdditionalOption
+            key = "PrefersMallocStackLoggingLite"
+            value = ""
+            isEnabled = "YES">
+         </AdditionalOption>
+         <AdditionalOption
+            key = "MallocScribble"
+            value = ""
+            isEnabled = "YES">
+         </AdditionalOption>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4DF6E43527F6E90700C43208"
+            BuildableName = "MemoryTest.app"
+            BlueprintName = "MemoryTest"
+            ReferencedContainer = "container:RMQClient.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/RMQClient/RMQAllocatedChannel.m
+++ b/RMQClient/RMQAllocatedChannel.m
@@ -60,7 +60,7 @@
 @property (nonatomic, readwrite) NSNumber *prefetchCountPerChannel;
 @property (nonatomic, readwrite) id<RMQConnectionDelegate> delegate;
 @property (nonatomic, readwrite) id<RMQNameGenerator> nameGenerator;
-@property (nonatomic, readwrite) id<RMQChannelAllocator> allocator;
+@property (nonatomic, weak, readwrite) id<RMQChannelAllocator> allocator;
 @end
 
 @implementation RMQAllocatedChannel

--- a/RMQClient/RMQConnection.m
+++ b/RMQClient/RMQConnection.m
@@ -67,9 +67,9 @@
 @property (nonatomic, readwrite) id <RMQFrameHandler> frameHandler;
 @property (nonatomic, readwrite) id<RMQLocalSerialQueue> commandQueue;
 @property (nonatomic, readwrite) id<RMQWaiterFactory> waiterFactory;
-@property (nonatomic, readwrite) id<RMQHeartbeatSender> heartbeatSender;
+@property (nonatomic, weak, readwrite) id<RMQHeartbeatSender> heartbeatSender;
 @property (nonatomic, weak, readwrite) id<RMQConnectionDelegate> delegate;
-@property (nonatomic, readwrite) id <RMQChannel> channelZero;
+@property (nonatomic, weak, readwrite) id <RMQChannel> channelZero;
 @property (nonatomic, readwrite) RMQConnectionConfig *config;
 @property (nonatomic, readwrite) NSMutableDictionary *userChannels;
 @property (nonatomic, readwrite) NSNumber *frameMax;

--- a/RMQClient/RMQConnection.m
+++ b/RMQClient/RMQConnection.m
@@ -623,8 +623,6 @@ static void RMQInitConnectionConfigDefaults() {
     for (RMQOperation operation in self.safeCloseOperations) {
         [self.commandQueue enqueue:operation];
     }
-    self.reader = nil;
-    self.frameHandler = nil;
 }
 
 - (void)blockingClose {
@@ -707,6 +705,13 @@ static void RMQInitConnectionConfigDefaults() {
               ^{
                   self.transport.delegate = nil;
                   [self.transport close];
+              },
+              ^{
+                  self.channelAllocator = nil;
+              },
+              ^{
+                  self.reader = nil;
+                  self.frameHandler = nil;
               }];
 }
 
@@ -719,6 +724,13 @@ static void RMQInitConnectionConfigDefaults() {
               ^{
                   self.transport.delegate = nil;
                   [self.transport close];
+              },
+              ^{
+                  self.channelAllocator = nil;
+              },
+              ^{
+                  self.reader = nil;
+                  self.frameHandler = nil;
               }];
 }
 

--- a/RMQClient/RMQConnection.m
+++ b/RMQClient/RMQConnection.m
@@ -559,22 +559,24 @@ static void RMQInitConnectionConfigDefaults() {
         [self.delegate connection:self failedToConnectWithError:connectError];
     } else {
         [self.transport write:[RMQProtocolHeader new].amqEncoded];
+        __weak id this = self;
 
         [self.commandQueue enqueue:^{
-            id<RMQWaiter> handshakeCompletion = [self.waiterFactory makeWithTimeout:self.handshakeTimeout];
+            __strong typeof(self) strongThis = this;
+            id<RMQWaiter> handshakeCompletion = [strongThis.waiterFactory makeWithTimeout:strongThis.handshakeTimeout];
 
-            RMQHandshaker *handshaker = [[RMQHandshaker alloc] initWithSender:self
-                                                                       config:self.config
+            RMQHandshaker *handshaker = [[RMQHandshaker alloc] initWithSender:strongThis
+                                                                       config:strongThis.config
                                                             completionHandler:^(NSNumber *heartbeatTimeout,
                                                                                 RMQTable *serverProperties) {
-                                                                [self.heartbeatSender startWithInterval:@(heartbeatTimeout.integerValue / 2)];
-                                                                self.handshakeComplete = YES;
+                                                                [strongThis.heartbeatSender startWithInterval:@(heartbeatTimeout.integerValue / 2)];
+                strongThis.handshakeComplete = YES;
                                                                 [handshakeCompletion done];
-                                                                [self.reader run];
-                                                                self.serverProperties = serverProperties;
+                                                                [strongThis.reader run];
+                strongThis.serverProperties = serverProperties;
                                                                 completionHandler();
                                                             }];
-            RMQReader *handshakeReader = [[RMQReader alloc] initWithTransport:self.transport
+            RMQReader *handshakeReader = [[RMQReader alloc] initWithTransport:strongThis.transport
                                                                  frameHandler:handshaker];
             handshaker.reader = handshakeReader;
             [handshakeReader run];
@@ -583,7 +585,7 @@ static void RMQInitConnectionConfigDefaults() {
                 NSError *error = [NSError errorWithDomain:RMQErrorDomain
                                                      code:RMQErrorConnectionHandshakeTimedOut
                                                  userInfo:@{NSLocalizedDescriptionKey: @"Handshake timed out."}];
-                [self.delegate connection:self failedToConnectWithError:error];
+                [strongThis.delegate connection:strongThis failedToConnectWithError:error];
             }
         }];
     }

--- a/RMQClient/RMQConnection.m
+++ b/RMQClient/RMQConnection.m
@@ -623,6 +623,8 @@ static void RMQInitConnectionConfigDefaults() {
     for (RMQOperation operation in self.safeCloseOperations) {
         [self.commandQueue enqueue:operation];
     }
+    self.reader = nil;
+    self.frameHandler = nil;
 }
 
 - (void)blockingClose {

--- a/RMQClient/RMQConnectionRecover.m
+++ b/RMQClient/RMQConnectionRecover.m
@@ -47,7 +47,7 @@
 @property (nonatomic, readwrite) NSUInteger attempts;
 @property (nonatomic, readwrite) NSUInteger attemptLimit;
 @property (nonatomic, readwrite) BOOL onlyErrors;
-@property (nonatomic, readwrite) id<RMQHeartbeatSender> heartbeatSender;
+@property (nonatomic, weak, readwrite) id<RMQHeartbeatSender> heartbeatSender;
 @property (nonatomic, readwrite) id<RMQLocalSerialQueue> commandQueue;
 @property (nonatomic, readwrite) id<RMQConnectionDelegate> delegate;
 @end

--- a/RMQClient/RMQReader.m
+++ b/RMQClient/RMQReader.m
@@ -61,16 +61,15 @@
 }
 
 - (void)run {
-    __weak id this = self;
     [self.transport readFrame:^(NSData * _Nonnull methodData) {
         // executing on a concurrent queue
-        __strong typeof(self) strongThis = this;
-        RMQFrame *frame = [strongThis frameWithData:methodData];
+        
+        RMQFrame *frame = [self frameWithData:methodData];
 
         if (frame.isHeartbeat) {
-            [strongThis run];
+            [self run];
         } else {
-            [strongThis handleMethodFrame:frame];
+            [self handleMethodFrame:frame];
         }
     }];
 }

--- a/RMQClient/RMQReader.m
+++ b/RMQClient/RMQReader.m
@@ -78,12 +78,10 @@
 
 - (void)handleMethodFrame:(RMQFrame *)frame {
     id<RMQMethod> method = (id<RMQMethod>)frame.payload;
-    __weak id this = self;
+
     if (method.hasContent) {
         [self.transport readFrame:^(NSData * _Nonnull headerData) {
-            __strong typeof(self) strongThis = this;
-
-            RMQFrame *headerFrame = [strongThis frameWithData:headerData];
+            RMQFrame *headerFrame = [self frameWithData:headerData];
             RMQContentHeader *header = (RMQContentHeader *)headerFrame.payload;
 
             RMQFrameset *frameset = [[RMQFrameset alloc] initWithChannelNumber:frame.channelNumber
@@ -91,9 +89,9 @@
                                                                  contentHeader:header
                                                                  contentBodies:@[]];
             if ([header.bodySize isEqualToNumber:@0]) {
-                [strongThis.frameHandler handleFrameset:frameset];
+                [self.frameHandler handleFrameset:frameset];
             } else {
-                [strongThis readBodiesForIncompleteFrameset:frameset];
+                [self readBodiesForIncompleteFrameset:frameset];
             }
         }];
     } else {

--- a/RMQClient/RMQReader.m
+++ b/RMQClient/RMQReader.m
@@ -45,7 +45,7 @@
 #import "RMQMethodDecoder.h"
 
 @interface RMQReader ()
-@property (nonatomic, readwrite) id<RMQTransport>transport;
+@property (nonatomic,weak, readwrite) id<RMQTransport>transport;
 @property (nonatomic, readwrite) id<RMQFrameHandler>frameHandler;
 @end
 

--- a/RMQClient/RMQSuspendResumeDispatcher.m
+++ b/RMQClient/RMQSuspendResumeDispatcher.m
@@ -51,7 +51,7 @@
 @property (nonatomic, readwrite) id<RMQLocalSerialQueue> commandQueue;
 @property (nonatomic, readwrite) id<RMQLocalSerialQueue> enablementQueue;
 @property (nonatomic, readwrite) NSNumber *enableDelay;
-@property (nonatomic, readwrite) id<RMQConnectionDelegate> delegate;
+@property (nonatomic,weak, readwrite) id<RMQConnectionDelegate> delegate;
 @property (nonatomic, readwrite) DispatcherState state;
 @property (nonatomic, readwrite) BOOL disabled;
 @end

--- a/RMQClient/RMQTCPSocketTransport.m
+++ b/RMQClient/RMQTCPSocketTransport.m
@@ -168,14 +168,15 @@ struct __attribute__((__packed__)) AMQPHeader {
 #define AMQP091_FINAL_OCTET_SIZE 1
 
 - (void)readFrame:(void (^)(NSData * _Nonnull))complete {
+    __weak id this = self;
     [self read:AMQP091_HEADER_SIZE complete:^(NSData * _Nonnull data) {
         const struct AMQPHeader *header;
         header = (const struct AMQPHeader *)data.bytes;
-        
+        __strong typeof(self) strongThis = this;
         UInt32 hostSize = CFSwapInt32BigToHost(header->size);
         
-        [self read:hostSize complete:^(NSData * _Nonnull payload) {
-            [self read:AMQP091_FINAL_OCTET_SIZE complete:^(NSData * _Nonnull frameEnd) {
+        [strongThis read:hostSize complete:^(NSData * _Nonnull payload) {
+            [strongThis read:AMQP091_FINAL_OCTET_SIZE complete:^(NSData * _Nonnull frameEnd) {
                 NSMutableData *allData = [data mutableCopy];
                 [allData appendData:payload];
                 complete(allData);

--- a/RMQClientTests/ConnectionClosureTest.swift
+++ b/RMQClientTests/ConnectionClosureTest.swift
@@ -48,7 +48,7 @@ class ConnectionClosureTest: XCTestCase {
         let allocator = ChannelSpyAllocator()
         let q = FakeSerialQueue()
         let handshakeCount = 1
-        let expectedCloseProcedureCount = 5
+        let expectedCloseProcedureCount = 7
         let channelsToCreateCount = 2
         let conn = RMQConnection(transport: transport,
                                  config: ConnectionWithFakesHelper.connectionConfig(),
@@ -187,7 +187,7 @@ class ConnectionClosureTest: XCTestCase {
         let transport = ControlledInteractionTransport()
         let allocator = ChannelSpyAllocator()
         let q = FakeSerialQueue()
-        let expectedCloseProcedureCount = 5
+        let expectedCloseProcedureCount = 7
         let channelsToCreateCount = 2
         let heartbeatSender = HeartbeatSenderSpy()
         let conn = RMQConnection(transport: transport,


### PR DESCRIPTION
for some important dependencies of allocated channels and
RMQConnection itself.

For example, in this client, RMQConnection auto-allocates a channel for
the purpose of special "channel zero" (system communication
in the protocol) purposes, and that leads to a loop
of strong references that prevent RMQConnection instances
from being released.

Based on object graph analysis by @BarryDuggan in https://github.com/rabbitmq/rabbitmq-objc-client/discussions/194.