### PR TITLE
Fixed crash when it tried to remove the first element in case its array is empty

### DIFF
--- a/RMQClient/RMQMultipleChannelAllocator.m
+++ b/RMQClient/RMQMultipleChannelAllocator.m
@@ -105,7 +105,9 @@
 
 - (NSArray *)allocatedUserChannels {
     NSMutableArray *userChannels = [self.channels.allValues mutableCopy];
-    [userChannels removeObjectAtIndex:0];
+    if ([userChannels count] > 0) {
+        [userChannels removeObjectAtIndex:0];
+    }
     return [userChannels sortedArrayUsingComparator:^NSComparisonResult(id<RMQChannel> ch1, id<RMQChannel> ch2) {
         return ch1.channelNumber.integerValue > ch2.channelNumber.integerValue;
     }];


### PR DESCRIPTION
I fixed the crash for that reported issue which I noted in https://github.com/rabbitmq/rabbitmq-objc-client/issues/236
@pivotal-cla This is an Obvious Fix